### PR TITLE
fix: remove coin symbol limitation with 1 char (support for Sonic)

### DIFF
--- a/src/prefs/BaseProviderConfigView.ts
+++ b/src/prefs/BaseProviderConfigView.ts
@@ -171,7 +171,7 @@ export class BaseProviderConfigView {
         if (!entry.text) {
           throw new Error();
         }
-        if (entry.text.length < 2) {
+        if (entry.text.length < 1) {
           return;
         }
         this._indicatorConfig.set(key, entry.text.toUpperCase());


### PR DESCRIPTION
There was a limitation for symbols that was limiting users to use a symbol with 1 character. For example, "S" as Sonic.