### PR TITLE
updating nobitex base url

### DIFF
--- a/src/providers/ProviderNobitex.ts
+++ b/src/providers/ProviderNobitex.ts
@@ -8,7 +8,7 @@ export class Api extends BaseProvider.Api {
   interval = 15;
 
   getUrl({ base, quote }) {
-    return `https://api.nobitex.ir/v2/orderbook/${base}${quote}`;
+    return `https://apiv2.nobitex.ir/v3/orderbook/${base}${quote}`;
   }
 
   getLast({ lastTradePrice }, { quote }) {


### PR DESCRIPTION
hi, i use this extention for nobitex api and based on nobitex new API doc, the base url needs to be updated.

```
curl 'https://apiv2.nobitex.ir/v3/orderbook/BTCIRT'
در صورت فراخوانی درست، پاسخ به این صورت خواهد بود:

{
    "status": "ok",
    "lastUpdate": 1644991756704,
    "lastTradePrice": "35650565900",
    "asks": [
        ["1476091000", "1.016"],
        ["1479700000", "0.2561"]
    ],
    "bids": [
        ["1470001120", "0.126571"],
        ["1470000000", "0.818994"]
    ]
}
```