### PR TITLE
Add support for GNOME version 49

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["46", "47", "48"],
+  "shell-version": ["46", "47", "48", "49"],
   "uuid": "bitcoin-markets@ottoallmendinger.github.com",
   "name": "Bitcoin Markets",
   "url": "https://github.com/OttoAllmendinger/gnome-shell-bitcoin-markets/",


### PR DESCRIPTION
Add GNOME v49 to `metadata.json`.
Also the Github "Issues" feature is not enabled for your repository, thus we cant open issues for bugs/feature requests like bumping the GNOME version. Would be great if you'd enable it.