### PR TITLE
Fix make dependency, README for first usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The latest development version can be installed manually with these commands
 
         git clone https://github.com/rossigee/gnome-shell-bitcoin-markets.git
         cd gnome-shell-bitcoin-markets
+        npm install
         make
         make install
 

--- a/scripts/make/gnome-shell-extension.mk
+++ b/scripts/make/gnome-shell-extension.mk
@@ -30,7 +30,7 @@ node_modules:
 .PHONY: archive
 archive: $(ZIPFILE)
 
-$(ZIPFILE): res/metadata.json schemas
+$(ZIPFILE): dist/ res/metadata.json schemas
 	-rm $(ZIPFILE)
 	cd dist/ && zip ../$(ZIPFILE) *.js
 	cd res && zip ../$(ZIPFILE) \


### PR DESCRIPTION
Ensure `dist/` exists when attempting to delete the zipfile. Otherwise, the `rm` command in `clean` will fail.

Also add `npm install` to the README, because `make` depends on node modules.