### PR TITLE
Fix extension cleanup and add GNOME 50 support

### DIFF
--- a/src/ApiService.ts
+++ b/src/ApiService.ts
@@ -1,4 +1,4 @@
-import { timeoutAdd, timeoutRemove } from './timeouts';
+import { idleAdd, timeoutAdd, timeoutRemove } from './timeouts';
 import * as Config from '@gnome-shell/misc/config';
 import Glib from '@girs/glib-2.0';
 import Gio from '@girs/gio-2.0';
@@ -128,6 +128,10 @@ class PriceDataLog {
 
     return keys.map((k: Date) => ({ date: k, value: values.get(k)! }));
   }
+
+  clear() {
+    this.map.clear();
+  }
 }
 
 const getSubscriberUrl = ({ options }: Subscriber) => getProvider(options.api).getUrl(options);
@@ -143,6 +147,7 @@ class PollLoop {
   private subscribers: any[] = [];
   private urls: string[] = [];
   private _cancellable: Gio.Cancellable | null = null;
+  private retryTimeouts = new Map<number, () => void>();
 
   constructor(provider: BaseProvider.Api) {
     const interval = Number(provider.interval);
@@ -156,9 +161,8 @@ class PollLoop {
   start(): boolean {
     if (this.signal === null) {
       this._cancellable = new Gio.Cancellable();
-      this.signal = Glib.idle_add(Glib.PRIORITY_DEFAULT, () => {
+      this.signal = idleAdd(() => {
         this.run();
-        return Glib.SOURCE_REMOVE;
       });
       return true;
     }
@@ -172,6 +176,32 @@ class PollLoop {
     }
     this._cancellable?.cancel();
     this._cancellable = null;
+    this.retryTimeouts.forEach((resolve, sourceId) => {
+      timeoutRemove(sourceId);
+      resolve();
+    });
+    this.retryTimeouts.clear();
+  }
+
+  destroy() {
+    this.stop();
+    this.cache.clear();
+    this.priceDataLog.clear();
+    this.subscribers = [];
+    this.urls = [];
+  }
+
+  private waitForRetry(delay: number): Promise<void> {
+    return new Promise((resolve) => {
+      const sourceId = timeoutAdd(delay, () => {
+        this.retryTimeouts.delete(sourceId);
+        resolve();
+      });
+      this.retryTimeouts.set(sourceId, () => {
+        this.retryTimeouts.delete(sourceId);
+        resolve();
+      });
+    });
   }
 
   run() {
@@ -279,7 +309,7 @@ class PollLoop {
           // Calculate exponential backoff delay
           const delay = baseDelay * Math.pow(2, attempt);
           console.log(`Request failed, retrying in ${delay}ms... (attempt ${attempt + 1}/${maxRetries})`);
-          await new Promise((resolve) => timeoutAdd(delay, () => resolve(undefined)));
+          await this.waitForRetry(delay);
           if (this._cancellable === null) {
             return; // Loop was stopped during retry delay
           }
@@ -324,4 +354,15 @@ export function setSubscribers(subscribers: Subscriber[]) {
   });
 
   _pollLoops.forEach((loop) => loop.setSubscribers(subscribers));
+}
+
+export function destroy() {
+  _pollLoops.forEach((loop) => loop.destroy());
+
+  permanentErrorTimeouts.forEach((sourceId) => {
+    timeoutRemove(sourceId);
+  });
+  permanentErrorTimeouts.clear();
+  permanentErrors.clear();
+  circuitBreakers.clear();
 }

--- a/src/ApiService.ts
+++ b/src/ApiService.ts
@@ -1,6 +1,5 @@
 import { idleAdd, timeoutAdd, timeoutRemove } from './timeouts';
 import * as Config from '@gnome-shell/misc/config';
-import Glib from '@girs/glib-2.0';
 import Gio from '@girs/gio-2.0';
 
 import * as HTTP from './HTTP';
@@ -209,6 +208,10 @@ class PollLoop {
       this.update();
     } catch (e) {
       console.error(e);
+    }
+
+    if (this._cancellable === null) {
+      return;
     }
 
     this.signal = timeoutAdd(this.interval * 1000, this.run.bind(this));

--- a/src/HTTP.ts
+++ b/src/HTTP.ts
@@ -88,6 +88,10 @@ class RateLimiter {
     this.requestLog.push({ uri, date: now });
     return false;
   }
+
+  clear(): void {
+    this.requestLog = [];
+  }
 }
 
 const rateLimiter = new RateLimiter(1_000, 8);
@@ -99,6 +103,11 @@ export function destroySession(): void {
     _session.abort();
     _session = null;
   }
+}
+
+export function destroy(): void {
+  destroySession();
+  rateLimiter.clear();
 }
 
 export async function getJSON(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,6 @@ type PopupMenuItemWithLabel = PopupMenu.PopupMenuItem & {
   label: St.Label;
 };
 
-@registerGObjectClass
 class MarketIndicatorView extends PanelMenu.Button {
   options?: IndicatorOptions;
   providerLabel!: string;
@@ -94,7 +93,7 @@ class MarketIndicatorView extends PanelMenu.Button {
       hover: false,
       can_focus: false,
     }) as PopupMenuItemWithLabel;
-    this._popupItemStatus.label.set_style('max-width: 12em;');
+    (this._popupItemStatus.label as any).set_style('max-width: 12em;');
     (this._popupItemStatus.label as any).clutter_text.set_line_wrap(true);
     (this.menu as PopupMenu.PopupMenu).addMenuItem(this._popupItemStatus);
 
@@ -180,9 +179,11 @@ class MarketIndicatorView extends PanelMenu.Button {
 
 }
 
+const RegisteredMarketIndicatorView = registerGObjectClass(MarketIndicatorView);
+
 class IndicatorCollection {
   private settings: Gio.Settings;
-  private _indicators: InstanceType<typeof MarketIndicatorView>[];
+  private _indicators: InstanceType<typeof RegisteredMarketIndicatorView>[];
   private _settingsChangedId: number;
 
   constructor(private ext: ExtensionBase) {
@@ -273,7 +274,7 @@ class IndicatorCollection {
     } else {
       this._removeAll();
       const indicators = arrOptions.map((options) => {
-        return new MarketIndicatorView(this.ext, options);
+        return new RegisteredMarketIndicatorView(this.ext, options);
       });
       indicators.forEach((view, i) => {
         Main.panel.addToStatusArea(`bitcoin-market-indicator-${i}`, view);
@@ -314,7 +315,8 @@ export default class BitcoinMarketsExtension extends Extension {
   disable(): void {
     this._indicatorCollection?.destroy();
     this._indicatorCollection = null;
+    ApiService.destroy();
     removeAllTimeouts();
-    HTTP.destroySession();
+    HTTP.destroy();
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,8 +32,26 @@ interface IndicatorOptions extends Options {
   show_change: boolean;
 }
 
+type ClutterTextLike = {
+  set_line_wrap(wrap: boolean): void;
+  set_markup(markup: string): void;
+};
+
+type StLabelWithClutterText = {
+  set_style(style: string): void;
+  clutter_text: ClutterTextLike;
+};
+
 type PopupMenuItemWithLabel = PopupMenu.PopupMenuItem & {
-  label: St.Label;
+  label: StLabelWithClutterText;
+};
+
+type ActorContainer = {
+  add_child(child: Clutter.Actor): void;
+};
+
+type PreferencesOpener = ExtensionBase & {
+  openPreferences(): void | Promise<void>;
 };
 
 class MarketIndicatorView extends PanelMenu.Button {
@@ -67,7 +85,7 @@ class MarketIndicatorView extends PanelMenu.Button {
   }
 
   destroy(): void {
-    (PanelMenu.Button.prototype as any).destroy.call(this);
+    PanelMenu.Button.prototype.destroy.call(this);
   }
 
   _initLayout() {
@@ -86,15 +104,15 @@ class MarketIndicatorView extends PanelMenu.Button {
     layout.add_child(this._statusView);
     layout.add_child(this._indicatorView);
 
-    (this as any).add_child(layout);
+    (this as unknown as ActorContainer).add_child(layout);
 
     this._popupItemStatus = new PopupMenu.PopupMenuItem('', {
       activate: false,
       hover: false,
       can_focus: false,
     }) as PopupMenuItemWithLabel;
-    (this._popupItemStatus.label as any).set_style('max-width: 12em;');
-    (this._popupItemStatus.label as any).clutter_text.set_line_wrap(true);
+    this._popupItemStatus.label.set_style('max-width: 12em;');
+    this._popupItemStatus.label.clutter_text.set_line_wrap(true);
     (this.menu as PopupMenu.PopupMenu).addMenuItem(this._popupItemStatus);
 
     (this.menu as PopupMenu.PopupMenu).addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
@@ -103,8 +121,8 @@ class MarketIndicatorView extends PanelMenu.Button {
     (this.menu as PopupMenu.PopupMenu).addMenuItem(this._popupItemSettings);
     const extRef = this.ext;
     this._popupItemSettings.connect('activate', () => {
-      const ext = extRef as ExtensionBase;
-      Promise.resolve((ext as any).openPreferences()).catch((err: unknown) => {
+      const ext = extRef as PreferencesOpener;
+      Promise.resolve(ext.openPreferences()).catch((err: unknown) => {
         console.error('Failed to open preferences:', err);
       });
     });
@@ -174,12 +192,18 @@ class MarketIndicatorView extends PanelMenu.Button {
     if (err) {
       text += '\n\n' + (err instanceof HTTP.HTTPError ? err.format('\n\n') : String(err));
     }
-    (this._popupItemStatus.label as any).clutter_text.set_markup(text);
+    this._popupItemStatus.label.clutter_text.set_markup(text);
   }
 
 }
 
 const RegisteredMarketIndicatorView = registerGObjectClass(MarketIndicatorView);
+
+function hasOptions(
+  indicator: InstanceType<typeof RegisteredMarketIndicatorView>,
+): indicator is InstanceType<typeof RegisteredMarketIndicatorView> & ApiService.Subscriber {
+  return indicator.options !== undefined;
+}
 
 class IndicatorCollection {
   private settings: Gio.Settings;
@@ -282,7 +306,7 @@ class IndicatorCollection {
       this._indicators = indicators;
     }
 
-    ApiService.setSubscribers(this._indicators.filter((i) => i.options) as ApiService.Subscriber[]);
+    ApiService.setSubscribers(this._indicators.filter(hasOptions));
   }
 
   _removeAll() {

--- a/src/gjs.ts
+++ b/src/gjs.ts
@@ -24,3 +24,15 @@ export function registerGObjectClass<
     return GObject.registerClass<K, T>(target) as typeof target;
   }
 }
+
+export function registerGObjectClassWithMetaInfo<
+  K,
+  T extends { new (...params: any[]): K },
+  P = Record<string, never>,
+  S = Record<string, never>,
+  I = never,
+>(metaInfo: GObject.MetaInfo<P, S, I>, target: T) {
+  // GIR typings do not model the overload well, so keep the workaround here.
+  // @ts-ignore
+  return GObject.registerClass<K, T>(metaInfo, target) as typeof target;
+}

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["46", "47", "48", "49"],
+  "shell-version": ["46", "47", "48", "49", "50"],
   "uuid": "bitcoin-markets@ottoallmendinger.github.com",
   "name": "Bitcoin Markets",
   "url": "https://github.com/rossigee/gnome-shell-bitcoin-markets/",

--- a/src/prefs/BaseProviderConfigView.ts
+++ b/src/prefs/BaseProviderConfigView.ts
@@ -4,7 +4,6 @@ import GLib from '@girs/glib-2.0';
 
 import * as BaseProvider from '../providers/BaseProvider';
 import { getProvider } from '../providers';
-import { registerGObjectClass } from '../gjs';
 
 import { ComboBoxOptions } from './prefs';
 import { ConfigModel } from './IndicatorCollectionModel'
@@ -52,7 +51,6 @@ function debounce(milliseconds: number, func: () => void): { callback: () => voi
   };
 }
 
-@registerGObjectClass
 export class ComboBoxView extends GObject.Object {
   static metaInfo: GObject.MetaInfo<Record<string, never>, Record<string, never>, any> = {
     GTypeName: 'ComboBoxView',
@@ -111,6 +109,11 @@ export class ComboBoxView extends GObject.Object {
     });
   }
 }
+
+export const RegisteredComboBoxView = GObject.registerClass(
+  ComboBoxView.metaInfo as any,
+  ComboBoxView,
+) as typeof ComboBoxView;
 
 type GettextFunc = (s: string) => string;
 

--- a/src/prefs/BaseProviderConfigView.ts
+++ b/src/prefs/BaseProviderConfigView.ts
@@ -1,6 +1,7 @@
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
 import GLib from '@girs/glib-2.0';
+import { registerGObjectClassWithMetaInfo } from '../gjs';
 
 import * as BaseProvider from '../providers/BaseProvider';
 import { getProvider } from '../providers';
@@ -110,8 +111,8 @@ export class ComboBoxView extends GObject.Object {
   }
 }
 
-export const RegisteredComboBoxView = GObject.registerClass(
-  ComboBoxView.metaInfo as any,
+export const RegisteredComboBoxView = registerGObjectClassWithMetaInfo(
+  ComboBoxView.metaInfo,
   ComboBoxView,
 ) as typeof ComboBoxView;
 

--- a/src/prefs/BaseProviderConfigView.ts
+++ b/src/prefs/BaseProviderConfigView.ts
@@ -53,7 +53,7 @@ function debounce(milliseconds: number, func: () => void): { callback: () => voi
 }
 
 export class ComboBoxView extends GObject.Object {
-  static metaInfo: GObject.MetaInfo<Record<string, never>, Record<string, never>, any> = {
+  static metaInfo: GObject.MetaInfo<Record<string, never>, Record<string, never>, unknown> = {
     GTypeName: 'ComboBoxView',
     Signals: {
       changed: {
@@ -114,7 +114,7 @@ export class ComboBoxView extends GObject.Object {
 export const RegisteredComboBoxView = registerGObjectClassWithMetaInfo(
   ComboBoxView.metaInfo,
   ComboBoxView,
-) as typeof ComboBoxView;
+);
 
 type GettextFunc = (s: string) => string;
 

--- a/src/prefs/IndicatorCollectionModel.ts
+++ b/src/prefs/IndicatorCollectionModel.ts
@@ -3,7 +3,6 @@ import GObject from '@girs/gobject-2.0';
 import Gio from '@girs/gio-2.0';
 
 import { getProvider } from '../providers';
-import { registerGObjectClass } from '../gjs';
 import { Defaults } from '../defaults';
 
 const INDICATORS_KEY = 'indicators';
@@ -28,7 +27,6 @@ export class ConfigModel {
   }
 }
 
-@registerGObjectClass
 export class IndicatorCollectionModel extends Gtk.ListStore {
   private _settings: Gio.Settings;
   private Columns: Record<string, number> = {};
@@ -132,3 +130,7 @@ export class IndicatorCollectionModel extends Gtk.ListStore {
     this._writeSettings();
   }
 }
+
+export const RegisteredIndicatorCollectionModel = GObject.registerClass(
+  IndicatorCollectionModel,
+) as typeof IndicatorCollectionModel;

--- a/src/prefs/IndicatorCollectionModel.ts
+++ b/src/prefs/IndicatorCollectionModel.ts
@@ -1,6 +1,7 @@
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
 import Gio from '@girs/gio-2.0';
+import { registerGObjectClass } from '../gjs';
 
 import { getProvider } from '../providers';
 import { Defaults } from '../defaults';
@@ -11,15 +12,15 @@ export class ConfigModel {
   private attributes: Record<string, unknown>;
 
   constructor(private listStore: Gtk.ListStore, private iter: Gtk.TreeIter, private column = 1) {
-    this.attributes = JSON.parse(this.listStore.get_value(iter, this.column));
+    this.attributes = JSON.parse(String(this.listStore.get_value(iter, this.column)));
   }
 
-  set(key: string, value: any) {
+  set(key: string, value: unknown) {
     this.attributes[key] = value;
     this.listStore.set(this.iter, [this.column], [JSON.stringify(this.attributes)]);
   }
 
-  get(key) {
+  get(key: string) {
     if (key in this.attributes) {
       return this.attributes[key];
     }
@@ -81,8 +82,7 @@ export class IndicatorCollectionModel extends Gtk.ListStore {
 
     const configs = this._settings.get_strv(INDICATORS_KEY);
 
-    Object.keys(configs).forEach((key) => {
-      const json = configs[key];
+    configs.forEach((json) => {
       try {
         const label = this._getLabel(JSON.parse(json));
         this.set(this.append(), [this.Columns.LABEL, this.Columns.CONFIG], [label, json]);
@@ -96,10 +96,10 @@ export class IndicatorCollectionModel extends Gtk.ListStore {
   _writeSettings() {
     // eslint-disable-next-line
     let [res, iter] = this.get_iter_first();
-    const configs: any[] = [];
+    const configs: string[] = [];
 
     while (res) {
-      configs.push(this.get_value(iter, this.Columns.CONFIG));
+      configs.push(String(this.get_value(iter, this.Columns.CONFIG)));
       res = this.iter_next(iter);
     }
 
@@ -107,10 +107,10 @@ export class IndicatorCollectionModel extends Gtk.ListStore {
   }
 
   _onRowChanged(self, path, iter) {
-    const config = this.get_value(iter, this.Columns.CONFIG);
+    const config = String(this.get_value(iter, this.Columns.CONFIG));
 
     this.set(iter, [this.Columns.LABEL, this.Columns.CONFIG], ([
-      this._getLabel(JSON.parse(config as any)),
+      this._getLabel(JSON.parse(config)),
       config,
     ] as unknown) as GObject.Value[]);
 
@@ -131,6 +131,6 @@ export class IndicatorCollectionModel extends Gtk.ListStore {
   }
 }
 
-export const RegisteredIndicatorCollectionModel = GObject.registerClass(
+export const RegisteredIndicatorCollectionModel = registerGObjectClass(
   IndicatorCollectionModel,
-) as typeof IndicatorCollectionModel;
+);

--- a/src/prefs/prefs.ts
+++ b/src/prefs/prefs.ts
@@ -13,10 +13,6 @@ const { RegisteredComboBoxView: ComboBoxView, makeConfigRow } = BaseProviderConf
 import { ConfigModel, RegisteredIndicatorCollectionModel as IndicatorCollectionModel } from './IndicatorCollectionModel';
 import { GettextFunc } from './gettext';
 
-type WidgetContainer = {
-  append(child: Gtk.Widget): void;
-};
-
 type PreferencesGroupWithWidgetAdd = Adw.PreferencesGroup & {
   add(child: Gtk.Widget): void;
 };
@@ -204,8 +200,8 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
       width_request: 240,
     });
 
-    (sidebar as WidgetContainer).append(this._getTreeView());
-    (sidebar as WidgetContainer).append(this._getToolbar());
+    sidebar.append(this._getTreeView());
+    sidebar.append(this._getToolbar());
 
     this.append(sidebar);
 

--- a/src/prefs/prefs.ts
+++ b/src/prefs/prefs.ts
@@ -1,8 +1,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
-import GObject from '@girs/gobject-2.0';
 import { ExtensionBase } from '@gnome-shell/extensions/extension';
 import { ExtensionPreferences } from '@gnome-shell/extensions/prefs';
+import { registerGObjectClass } from '../gjs';
 
 import * as Format from '../format/Format';
 import { getProvider, Providers } from '../providers';
@@ -12,6 +12,14 @@ import * as BaseProviderConfigView from './BaseProviderConfigView';
 const { RegisteredComboBoxView: ComboBoxView, makeConfigRow } = BaseProviderConfigView;
 import { ConfigModel, RegisteredIndicatorCollectionModel as IndicatorCollectionModel } from './IndicatorCollectionModel';
 import { GettextFunc } from './gettext';
+
+type WidgetContainer = {
+  append(child: Gtk.Widget): void;
+};
+
+type PreferencesGroupWithWidgetAdd = Adw.PreferencesGroup & {
+  add(child: Gtk.Widget): void;
+};
 
 export interface ComboBoxOptions {
   value: string;
@@ -196,8 +204,8 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
       width_request: 240,
     });
 
-    sidebar.append(this._getTreeView() as unknown as Gtk.Widget);
-    sidebar.append(this._getToolbar() as unknown as Gtk.Widget);
+    (sidebar as WidgetContainer).append(this._getTreeView());
+    (sidebar as WidgetContainer).append(this._getToolbar());
 
     this.append(sidebar);
 
@@ -218,7 +226,7 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
     this._selection.connect('changed', this._onSelectionChanged.bind(this));
   }
 
-  _getTreeView() {
+  _getTreeView(): Gtk.TreeView {
     this._treeView = new Gtk.TreeView({
       model: this._store,
       headers_visible: false,
@@ -236,7 +244,7 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
     return this._treeView;
   }
 
-  _getToolbar() {
+  _getToolbar(): Gtk.Box {
     const toolbar = (this._toolbar = new Gtk.Box({}));
 
     /* new widget button with menu */
@@ -318,19 +326,17 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
   }
 }
 
-const RegisteredBitcoinMarketsSettingsWidget = GObject.registerClass(
+const RegisteredBitcoinMarketsSettingsWidget = registerGObjectClass(
   BitcoinMarketsSettingsWidget,
-) as typeof BitcoinMarketsSettingsWidget;
+);
 
 export default class BitcoinMarketsSettings extends ExtensionPreferences {
   fillPreferencesWindow(window: Adw.PreferencesWindow): void {
     const page = new Adw.PreferencesPage();
     const gtkWidget = new RegisteredBitcoinMarketsSettingsWidget(this);
 
-    // In GNOME 49+, PreferencesPage.add() expects an AdwPreferencesGroup
-    // We need to wrap our Gtk.Box in a proper container
     const group = new Adw.PreferencesGroup();
-    group.add(gtkWidget as unknown as Adw.PreferencesGroup);
+    (group as PreferencesGroupWithWidgetAdd).add(gtkWidget);
     page.add(group);
 
     window.connect('close-request', () => {

--- a/src/prefs/prefs.ts
+++ b/src/prefs/prefs.ts
@@ -1,16 +1,16 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
+import GObject from '@girs/gobject-2.0';
 import { ExtensionBase } from '@gnome-shell/extensions/extension';
 import { ExtensionPreferences } from '@gnome-shell/extensions/prefs';
 
-import { registerGObjectClass } from '../gjs';
 import * as Format from '../format/Format';
 import { getProvider, Providers } from '../providers';
 
 import * as BaseProviderConfigView from './BaseProviderConfigView';
 
-const { ComboBoxView, makeConfigRow } = BaseProviderConfigView;
-import { ConfigModel, IndicatorCollectionModel } from './IndicatorCollectionModel';
+const { RegisteredComboBoxView: ComboBoxView, makeConfigRow } = BaseProviderConfigView;
+import { ConfigModel, RegisteredIndicatorCollectionModel as IndicatorCollectionModel } from './IndicatorCollectionModel';
 import { GettextFunc } from './gettext';
 
 export interface ComboBoxOptions {
@@ -98,6 +98,13 @@ class IndicatorConfigView {
     }
   }
 
+  destroy() {
+    if (this._apiConfigView) {
+      this._apiConfigView.destroy();
+      this._apiConfigView = undefined;
+    }
+  }
+
   _confFormat(): Gtk.Widget {
     const format = this._indicatorConfig.get('format');
 
@@ -160,7 +167,6 @@ class IndicatorConfigView {
   }
 }
 
-@registerGObjectClass
 class BitcoinMarketsSettingsWidget extends Gtk.Box {
   private gettext: GettextFunc;
   private _store?: InstanceType<typeof IndicatorCollectionModel>;
@@ -263,6 +269,7 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
 
   _showIndicatorConfig(indicatorConfig: ConfigModel | null) {
     if (this._indicatorConfigView) {
+      this._indicatorConfigView.destroy();
       this._configLayout!.remove(this._indicatorConfigView.widget);
       this._indicatorConfigView = null;
     }
@@ -304,18 +311,32 @@ class BitcoinMarketsSettingsWidget extends Gtk.Box {
 
     this._updateToolbar();
   }
+
+  destroyView() {
+    this._indicatorConfigView?.destroy();
+    this._indicatorConfigView = null;
+  }
 }
+
+const RegisteredBitcoinMarketsSettingsWidget = GObject.registerClass(
+  BitcoinMarketsSettingsWidget,
+) as typeof BitcoinMarketsSettingsWidget;
 
 export default class BitcoinMarketsSettings extends ExtensionPreferences {
   fillPreferencesWindow(window: Adw.PreferencesWindow): void {
     const page = new Adw.PreferencesPage();
-    const gtkWidget = new BitcoinMarketsSettingsWidget(this);
+    const gtkWidget = new RegisteredBitcoinMarketsSettingsWidget(this);
 
     // In GNOME 49+, PreferencesPage.add() expects an AdwPreferencesGroup
     // We need to wrap our Gtk.Box in a proper container
     const group = new Adw.PreferencesGroup();
     group.add(gtkWidget as unknown as Adw.PreferencesGroup);
     page.add(group);
+
+    window.connect('close-request', () => {
+      gtkWidget.destroyView();
+      return false;
+    });
 
     window.add(page);
   }

--- a/src/timeouts.ts
+++ b/src/timeouts.ts
@@ -1,6 +1,23 @@
 import GLib from '@girs/glib-2.0';
 
-const timeoutIds: number[] = [];
+const sourceIds = new Set<number>();
+
+function trackSource(sourceId: number): number {
+  sourceIds.add(sourceId);
+  return sourceId;
+}
+
+function untrackSource(sourceId: number): boolean {
+  return sourceIds.delete(sourceId);
+}
+
+export function sourceRemove(sourceId: number): boolean {
+  if (!untrackSource(sourceId)) {
+    return false;
+  }
+
+  return GLib.source_remove(sourceId);
+}
 
 /**
  * Add single-shot timeout
@@ -8,30 +25,30 @@ const timeoutIds: number[] = [];
  * @param callback
  */
 export function timeoutAdd(intervalMS: number, callback: () => void): number {
-  const sourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, intervalMS, () => {
+  const sourceId = trackSource(GLib.timeout_add(GLib.PRIORITY_DEFAULT, intervalMS, () => {
+    untrackSource(sourceId);
     callback();
-    // Remove this timeout ID from the array after it fires
-    const index = timeoutIds.indexOf(sourceId);
-    if (index > -1) {
-      timeoutIds.splice(index, 1);
-    }
     return GLib.SOURCE_REMOVE;
-  });
-  timeoutIds.push(sourceId);
+  }));
+  return sourceId;
+}
+
+export function idleAdd(callback: () => void): number {
+  const sourceId = trackSource(GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+    untrackSource(sourceId);
+    callback();
+    return GLib.SOURCE_REMOVE;
+  }));
+
   return sourceId;
 }
 
 export function timeoutRemove(sourceId: number): void {
-  const index = timeoutIds.indexOf(sourceId);
-  if (index > -1) {
-    timeoutIds.splice(index, 1);
-  }
-  GLib.source_remove(sourceId);
+  sourceRemove(sourceId);
 }
 
 export function removeAllTimeouts() {
-  timeoutIds.forEach((sourceId) => {
-    GLib.source_remove(sourceId);
-  });
-  timeoutIds.splice(0);
+  for (const sourceId of [...sourceIds]) {
+    sourceRemove(sourceId);
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "experimentalDecorators": true,
     "importHelpers": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary

- Add GNOME Shell 50 to metadata.
- Add explicit cleanup for `ApiService` and `HTTP` module state.
- Track and remove extension-owned GLib timeout/idle sources.
- Remove TypeScript decorator usage to avoid generated decorator helper artifacts in the packaged extension.

## Motivation

This addresses cleanup-related feedback from GNOME Extensions review [68028](https://extensions.gnome.org/review/68028) and keeps the extension compatible with GNOME Shell 50.

## Testing

- `npm test`
- `npx tsc --outDir build/`
- `make lint`
- `make clean`
- `make archive`
- `make install`
- Verified packaged `dist/prefs.js` contains no decorator helper artifacts such as `__decorate` or `tslib.__decorate`
- Reviewed disable/destroy paths for `ApiService`, `HTTP`, and tracked timeout/idle cleanup

